### PR TITLE
Merge and validate XTF files to test constraints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.xmlunit:xmlunit-core:2.9.1'
+    testImplementation "org.mockito:mockito-core:5.+"
 }
 
 application {

--- a/src/main/java/ch/geowerkstatt/interlis/testbed/runner/InterlisValidator.java
+++ b/src/main/java/ch/geowerkstatt/interlis/testbed/runner/InterlisValidator.java
@@ -33,6 +33,7 @@ public final class InterlisValidator implements Validator {
                     .command(
                             "java", "-jar", options.ilivalidatorPath().toString(),
                             "--log", logFile.toString(),
+                            "--modeldir", options.basePath() + ";%ITF_DIR;http://models.interlis.ch/;%JAR_DIR/ilimodels",
                             filePath.toString())
                     .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                     .redirectError(ProcessBuilder.Redirect.DISCARD)

--- a/src/main/java/ch/geowerkstatt/interlis/testbed/runner/Main.java
+++ b/src/main/java/ch/geowerkstatt/interlis/testbed/runner/Main.java
@@ -1,5 +1,6 @@
 package ch.geowerkstatt.interlis.testbed.runner;
 
+import ch.geowerkstatt.interlis.testbed.runner.xtf.XtfFileMerger;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -28,7 +29,8 @@ public final class Main {
 
         var testOptions = parseTestOptions(args);
         var validator = new InterlisValidator(testOptions);
-        var runner = new Runner(testOptions, validator);
+        var xtfMerger = new XtfFileMerger();
+        var runner = new Runner(testOptions, validator, xtfMerger);
         if (!runner.run()) {
             System.exit(1);
         }

--- a/src/main/java/ch/geowerkstatt/interlis/testbed/runner/Runner.java
+++ b/src/main/java/ch/geowerkstatt/interlis/testbed/runner/Runner.java
@@ -1,31 +1,37 @@
 package ch.geowerkstatt.interlis.testbed.runner;
 
+import ch.geowerkstatt.interlis.testbed.runner.xtf.XtfMerger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 
 public final class Runner {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final TestOptions options;
     private final Validator validator;
+    private final XtfMerger xtfMerger;
     private Path baseFilePath;
 
     /**
      * Creates a new instance of the Runner class.
      *
-     * @param options the test options.
+     * @param options   the test options.
      * @param validator the validator to use.
+     * @param xtfMerger the XTF merger to use.
      */
-    public Runner(TestOptions options, Validator validator) {
+    public Runner(TestOptions options, Validator validator, XtfMerger xtfMerger) {
         this.options = options;
         this.validator = validator;
+        this.xtfMerger = xtfMerger;
     }
 
     /**
      * Runs the testbed validation.
+     *
      * @return {@code true} if the validation was successful, {@code false} otherwise.
      */
     public boolean run() {
@@ -35,13 +41,17 @@ public final class Runner {
             if (!validateBaseData()) {
                 return false;
             }
+
+            if (!mergeAndValidateTransferFiles()) {
+                return false;
+            }
+
+            LOGGER.info("Validation of testbed completed.");
+            return true;
         } catch (ValidatorException e) {
             LOGGER.error("Validation could not run, check the configuration.", e);
             return false;
         }
-
-        LOGGER.info("Validation of testbed completed.");
-        return true;
     }
 
     private boolean validateBaseData() throws ValidatorException {
@@ -66,6 +76,39 @@ public final class Runner {
         } else {
             LOGGER.error("Validation of " + baseFilePath + " failed. See " + logFile + " for details.");
         }
+        return valid;
+    }
+
+    private boolean mergeAndValidateTransferFiles() throws ValidatorException {
+        List<Path> patchFiles;
+        try {
+            patchFiles = options.patchDataFiles();
+        } catch (IOException e) {
+            throw new ValidatorException(e);
+        }
+
+        if (patchFiles.isEmpty()) {
+            LOGGER.error("No patch files found.");
+            return false;
+        }
+
+        var valid = true;
+        for (var patchFile : patchFiles) {
+            var patchFileNameWithoutExtension = StringUtils.getFilenameWithoutExtension(patchFile.getFileName().toString());
+            var mergedFile = options.resolveOutputFilePath(patchFile, patchFileNameWithoutExtension + "_merged.xtf");
+            if (!xtfMerger.merge(baseFilePath, patchFile, mergedFile)) {
+                valid = false;
+                continue;
+            }
+
+            var logFile = mergedFile.getParent().resolve(patchFileNameWithoutExtension + ".log");
+            var mergedFileValid = validator.validate(mergedFile, logFile);
+            if (mergedFileValid) {
+                LOGGER.error("Validation of " + mergedFile + " was expected to fail but completed successfully.");
+                valid = false;
+            }
+        }
+
         return valid;
     }
 }

--- a/src/main/java/ch/geowerkstatt/interlis/testbed/runner/TestOptions.java
+++ b/src/main/java/ch/geowerkstatt/interlis/testbed/runner/TestOptions.java
@@ -32,6 +32,18 @@ public record TestOptions(Path basePath, Path ilivalidatorPath) {
     }
 
     /**
+     * Resolves the path to the output file based on the relative path of the input file.
+     *
+     * @param filePath    the path to the input file.
+     * @param newFileName the name of the output file.
+     * @return the path to the output file.
+     */
+    public Path resolveOutputFilePath(Path filePath, String newFileName) {
+        var relativePath = basePath.relativize(filePath.getParent());
+        return outputPath().resolve(relativePath).resolve(newFileName);
+    }
+
+    /**
      * Gets the path to the output directory.
      *
      * @return the path to the output directory.

--- a/src/main/java/ch/geowerkstatt/interlis/testbed/runner/TestOptions.java
+++ b/src/main/java/ch/geowerkstatt/interlis/testbed/runner/TestOptions.java
@@ -3,6 +3,8 @@ package ch.geowerkstatt.interlis.testbed.runner;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -26,8 +28,22 @@ public record TestOptions(Path basePath, Path ilivalidatorPath) {
      * @return the path to the base data file.
      */
     public Optional<Path> baseDataFilePath() throws IOException {
-        try (var dataFiles = findDataFiles(basePath)) {
+        try (var dataFiles = findDataFiles(basePath, 1)) {
             return dataFiles.findFirst();
+        }
+    }
+
+    /**
+     * Gets the paths to the patch data files.
+     *
+     * @return the paths to the patch data files.
+     */
+    public List<Path> patchDataFiles() throws IOException {
+        try (var dataFiles = findDataFiles(basePath, 2)) {
+            var outputPath = outputPath();
+            return dataFiles
+                    .filter(path -> !path.getParent().equals(basePath) && !path.startsWith(outputPath))
+                    .toList();
         }
     }
 
@@ -52,7 +68,11 @@ public record TestOptions(Path basePath, Path ilivalidatorPath) {
         return basePath.resolve(OUTPUT_DIR_NAME);
     }
 
-    private static Stream<Path> findDataFiles(Path basePath) throws IOException {
-        return Files.find(basePath, 1, (path, attributes) -> path.getFileName().toString().toLowerCase().endsWith(DATA_FILE_EXTENSION));
+    private static Stream<Path> findDataFiles(Path basePath, int maxDepth) throws IOException {
+        return Files.find(basePath, maxDepth, TestOptions::isDataFile);
+    }
+
+    private static boolean isDataFile(Path path, BasicFileAttributes attributes) {
+        return attributes.isRegularFile() && path.getFileName().toString().toLowerCase().endsWith(DATA_FILE_EXTENSION);
     }
 }

--- a/src/main/java/ch/geowerkstatt/interlis/testbed/runner/Validator.java
+++ b/src/main/java/ch/geowerkstatt/interlis/testbed/runner/Validator.java
@@ -7,8 +7,9 @@ public interface Validator {
      * Validates the given file.
      *
      * @param filePath the path to the file to validate.
+     * @param logFile  the path to the log file.
      * @return true if the validation was successful, false otherwise.
      * @throws ValidatorException if the validation could not be performed.
      */
-    boolean validate(Path filePath) throws ValidatorException;
+    boolean validate(Path filePath, Path logFile) throws ValidatorException;
 }

--- a/src/test/data/testbed-with-patches/constraintA/testcase-1.xtf
+++ b/src/test/data/testbed-with-patches/constraintA/testcase-1.xtf
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ili:transfer xmlns:ili="http://www.interlis.ch/xtf/2.4/INTERLIS">
+    <ili:datasection>
+    </ili:datasection>
+</ili:transfer>

--- a/src/test/data/testbed-with-patches/data.xtf
+++ b/src/test/data/testbed-with-patches/data.xtf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ili:transfer xmlns:ili="http://www.interlis.ch/xtf/2.4/INTERLIS">
+    <ili:headersection>
+        <ili:models>
+        </ili:models>
+        <ili:sender>interlis-testbed-runner</ili:sender>
+    </ili:headersection>
+    <ili:datasection>
+    </ili:datasection>
+</ili:transfer>

--- a/src/test/java/ch/geowerkstatt/interlis/testbed/runner/MockitoTestBase.java
+++ b/src/test/java/ch/geowerkstatt/interlis/testbed/runner/MockitoTestBase.java
@@ -1,0 +1,24 @@
+package ch.geowerkstatt.interlis.testbed.runner;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+import org.mockito.MockitoSession;
+import org.mockito.quality.Strictness;
+
+public abstract class MockitoTestBase {
+    private MockitoSession mockito;
+
+    @BeforeEach
+    public final void startMockitoSession() {
+        mockito = Mockito.mockitoSession()
+                .initMocks(this)
+                .strictness(Strictness.STRICT_STUBS)
+                .startMocking();
+    }
+
+    @AfterEach
+    public final void finishMockitoSession() {
+        mockito.finishMocking();
+    }
+}

--- a/src/test/java/ch/geowerkstatt/interlis/testbed/runner/RunnerBaseDataTest.java
+++ b/src/test/java/ch/geowerkstatt/interlis/testbed/runner/RunnerBaseDataTest.java
@@ -20,11 +20,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public final class RunnerTest extends MockitoTestBase {
+public final class RunnerBaseDataTest extends MockitoTestBase {
     private static final Path BASE_PATH = Path.of("src/test/data/testbed").toAbsolutePath().normalize();
-    private static final Path BASE_PATH_WITH_PATCHES = Path.of("src/test/data/testbed-with-patches").toAbsolutePath().normalize();
-    private static final Path ILI_VALIDATOR_PATH = Path.of("ilivalidator.jar");
+    private static final Path BASE_DATA_FILE = BASE_PATH.resolve("data.xtf");
 
+    private TestOptions options;
     private TestLogAppender appender;
     @Mock
     private Validator validatorMock;
@@ -33,6 +33,7 @@ public final class RunnerTest extends MockitoTestBase {
 
     @BeforeEach
     public void setup() {
+        options = new TestOptions(BASE_PATH, Path.of("ilivalidator.jar"));
         appender = TestLogAppender.registerAppender(Runner.class);
     }
 
@@ -46,7 +47,6 @@ public final class RunnerTest extends MockitoTestBase {
     public void runValidatesBaseData() throws IOException, ValidatorException {
         when(validatorMock.validate(any(), any())).thenReturn(true);
 
-        var options = new TestOptions(BASE_PATH, ILI_VALIDATOR_PATH);
         var runner = new Runner(options, validatorMock, mergerMock);
 
         var runResult = runner.run();
@@ -56,19 +56,17 @@ public final class RunnerTest extends MockitoTestBase {
         var errors = appender.getErrorMessages();
         assertIterableEquals(List.of("No patch files found."), errors);
 
-        var expectedBaseDataFile = BASE_PATH.resolve("data.xtf");
         var baseDataFile = options.baseDataFilePath();
         assertFalse(baseDataFile.isEmpty(), "Base data file should have been found.");
-        assertEquals(expectedBaseDataFile, baseDataFile.get());
+        assertEquals(BASE_DATA_FILE, baseDataFile.get());
 
-        verify(validatorMock).validate(eq(expectedBaseDataFile), any());
+        verify(validatorMock).validate(eq(BASE_DATA_FILE), any());
     }
 
     @Test
     public void runLogsValidationError() throws ValidatorException {
         when(validatorMock.validate(any(), any())).thenReturn(false);
 
-        var options = new TestOptions(BASE_PATH, ILI_VALIDATOR_PATH);
         var runner = new Runner(options, validatorMock, mergerMock);
 
         var runResult = runner.run();
@@ -82,33 +80,7 @@ public final class RunnerTest extends MockitoTestBase {
                 Pattern.matches("Validation of .*? failed\\..*", errorMessage),
                 "Error message should start with 'Validation of <base data file> failed.', actual value: '" + errorMessage + "'."
         );
-    }
 
-    @Test
-    public void runMergesAndValidatesPatchFiles() throws ValidatorException {
-        var expectedBaseDataFile = BASE_PATH_WITH_PATCHES.resolve("data.xtf");
-        var expectedPatchFile = BASE_PATH_WITH_PATCHES.resolve("constraintA").resolve("testcase-1.xtf");
-        var expectedMergedFile = BASE_PATH_WITH_PATCHES.resolve("output").resolve("constraintA").resolve("testcase-1_merged.xtf");
-
-        when(validatorMock.validate(eq(expectedBaseDataFile), any())).thenReturn(true);
-        when(validatorMock.validate(eq(expectedMergedFile), any())).thenReturn(false);
-
-        when(mergerMock.merge(any(), any(), any())).thenReturn(true);
-
-        var options = new TestOptions(BASE_PATH_WITH_PATCHES, ILI_VALIDATOR_PATH);
-
-        var runner = new Runner(options, validatorMock, mergerMock);
-
-        var runResult = runner.run();
-
-        assertTrue(runResult, "Testbed run should have succeeded.");
-
-        var errors = appender.getErrorMessages();
-        assertTrue(errors.isEmpty(), "No errors should have been logged.");
-
-        verify(validatorMock).validate(eq(expectedBaseDataFile), any());
-        verify(validatorMock).validate(eq(expectedMergedFile), any());
-
-        verify(mergerMock).merge(eq(expectedBaseDataFile), eq(expectedPatchFile), eq(expectedMergedFile));
+        verify(validatorMock).validate(eq(BASE_DATA_FILE), any());
     }
 }

--- a/src/test/java/ch/geowerkstatt/interlis/testbed/runner/RunnerTest.java
+++ b/src/test/java/ch/geowerkstatt/interlis/testbed/runner/RunnerTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,7 +37,7 @@ public final class RunnerTest {
     public void runValidatesBaseData() throws IOException {
         var validatedFiles = new ArrayList<Path>();
 
-        var runner = new Runner(options, file -> {
+        var runner = new Runner(options, (file, logFile) -> {
             validatedFiles.add(file.toAbsolutePath().normalize());
             return true;
         });
@@ -59,7 +60,7 @@ public final class RunnerTest {
 
     @Test
     public void runLogsValidationError() {
-        var runner = new Runner(options, file -> false);
+        var runner = new Runner(options, (file, logFile) -> false);
 
         var runResult = runner.run();
 
@@ -67,6 +68,10 @@ public final class RunnerTest {
 
         var errors = appender.getErrorMessages();
         assertEquals(1, errors.size(), "One error should have been logged.");
-        assertEquals("Validation of base data failed.", errors.getFirst());
+        var errorMessage = errors.getFirst();
+        assertTrue(
+                Pattern.matches("Validation of .*? failed\\..*", errorMessage),
+                "Error message should start with 'Validation of <base data file> failed.', actual value: '" + errorMessage + "'."
+        );
     }
 }

--- a/src/test/java/ch/geowerkstatt/interlis/testbed/runner/RunnerWithConstraintsTest.java
+++ b/src/test/java/ch/geowerkstatt/interlis/testbed/runner/RunnerWithConstraintsTest.java
@@ -1,0 +1,110 @@
+package ch.geowerkstatt.interlis.testbed.runner;
+
+import ch.geowerkstatt.interlis.testbed.runner.xtf.XtfMerger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class RunnerWithConstraintsTest extends MockitoTestBase {
+    private static final Path BASE_PATH = Path.of("src/test/data/testbed-with-patches").toAbsolutePath().normalize();
+    private static final String CONSTRAINT_NAME = "constraintA";
+    private static final Path BASE_DATA_FILE = BASE_PATH.resolve("data.xtf");
+    private static final Path PATCH_FILE = BASE_PATH.resolve(CONSTRAINT_NAME).resolve("testcase-1.xtf");
+    private static final Path MERGED_FILE = BASE_PATH.resolve("output").resolve(CONSTRAINT_NAME).resolve("testcase-1_merged.xtf");
+    private static final Path MERGED_LOG_FILE = BASE_PATH.resolve("output").resolve(CONSTRAINT_NAME).resolve("testcase-1.log");
+
+    private TestOptions options;
+    private TestLogAppender appender;
+    @Mock
+    private Validator validatorMock;
+    @Mock
+    private XtfMerger mergerMock;
+
+    @BeforeEach
+    public void setup() {
+        options = new TestOptions(BASE_PATH, Path.of("ilivalidator.jar"));
+        appender = TestLogAppender.registerAppender(Runner.class);
+
+        when(mergerMock.merge(any(), any(), any())).thenReturn(true);
+    }
+
+    @AfterEach
+    public void teardown() {
+        appender.stop();
+        appender.unregister();
+    }
+
+    @Test
+    public void runMergesAndValidatesPatchFiles() throws ValidatorException {
+        when(validatorMock.validate(eq(BASE_DATA_FILE), any())).thenReturn(true);
+        when(validatorMock.validate(MERGED_FILE, MERGED_LOG_FILE)).thenReturn(false);
+
+        var runner = new Runner(options, validatorMock, mergerMock);
+
+        var runResult = runner.run();
+
+        assertTrue(runResult, "Testbed run should have succeeded.");
+
+        var errors = appender.getErrorMessages();
+        assertTrue(errors.isEmpty(), "No errors should have been logged.");
+
+        verify(validatorMock).validate(eq(BASE_DATA_FILE), any());
+        verify(validatorMock).validate(eq(MERGED_FILE), eq(MERGED_LOG_FILE));
+
+        verify(mergerMock).merge(eq(BASE_DATA_FILE), eq(PATCH_FILE), eq(MERGED_FILE));
+    }
+
+    @Test
+    public void runFailsIfMergeFails() throws ValidatorException {
+        when(validatorMock.validate(eq(BASE_DATA_FILE), any())).thenReturn(true);
+        when(mergerMock.merge(eq(BASE_DATA_FILE), eq(PATCH_FILE), any())).thenReturn(false);
+
+        var runner = new Runner(options, validatorMock, mergerMock);
+
+        var runResult = runner.run();
+
+        assertFalse(runResult, "Testbed run should have failed if file merging failed.");
+
+        verify(validatorMock).validate(eq(BASE_DATA_FILE), any());
+        verify(validatorMock, never()).validate(eq(MERGED_FILE), eq(MERGED_LOG_FILE));
+
+        verify(mergerMock).merge(eq(BASE_DATA_FILE), eq(PATCH_FILE), eq(MERGED_FILE));
+    }
+
+    @Test
+    public void runFailsIfMergedFileIsValid() throws ValidatorException {
+        when(validatorMock.validate(eq(BASE_DATA_FILE), any())).thenReturn(true);
+        when(validatorMock.validate(MERGED_FILE, MERGED_LOG_FILE)).thenReturn(true);
+
+        var runner = new Runner(options, validatorMock, mergerMock);
+
+        var runResult = runner.run();
+
+        assertFalse(runResult, "Testbed run should have failed if merged file is valid.");
+
+        var errors = appender.getErrorMessages();
+        assertEquals(1, errors.size(), "One error should have been logged.");
+        var errorMessage = errors.getFirst();
+        assertTrue(
+                Pattern.matches("Validation of .*? was expected to fail but completed successfully\\.", errorMessage),
+                "Expected: Validation of <merged xtf file> was expected to fail but completed successfully. Actual: '" + errorMessage + "'.");
+
+        verify(validatorMock).validate(eq(BASE_DATA_FILE), any());
+        verify(validatorMock).validate(eq(MERGED_FILE), any());
+
+        verify(mergerMock).merge(eq(BASE_DATA_FILE), eq(PATCH_FILE), eq(MERGED_FILE));
+    }
+}


### PR DESCRIPTION
Integrates transfer file merging into the testbed runner.
The runner now:

- Checks that the base data file is valid
- Merges all XTF files that are in subfolders into `output/<subfolder>`
- Checks that the merged files are now invalid and writes their logs into `output/<subfolder>`

Checking the log files for failing constraint will be implemented later.