### PR TITLE
Add dependencies to classpath in jar manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ java {
 jar {
     manifest {
         attributes(
-                'Main-Class': application.mainClass
+                'Main-Class': application.mainClass,
+                'Class-Path': configurations.runtimeClasspath.collect { file -> file.getName() }.join(' ')
         )
     }
 }


### PR DESCRIPTION
This allows the runner to be started directly with "java -jar" when all required jar files are in the same directory.