### PR TITLE
Add verbose flag for validations

### DIFF
--- a/src/main/java/ch/geowerkstatt/interlis/testbed/runner/validation/InterlisValidator.java
+++ b/src/main/java/ch/geowerkstatt/interlis/testbed/runner/validation/InterlisValidator.java
@@ -34,6 +34,7 @@ public final class InterlisValidator implements Validator {
                     .command(
                             "java", "-jar", options.ilivalidatorPath().toString(),
                             "--log", logFile.toString(),
+                            "--verbose",
                             "--modeldir", options.basePath() + ";%ITF_DIR;http://models.interlis.ch/;%JAR_DIR/ilimodels")
                     .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                     .redirectError(ProcessBuilder.Redirect.DISCARD)


### PR DESCRIPTION
Der qualifizierte Name von Constraints mit einer custom Message (`!!@ ilivalid.msg="...";`) wird nur mit der `--verbose` Option ins Logfile geschrieben. Diese Log-Einträge werden zur Überprüfung benötigt.